### PR TITLE
默认情况下随机均衡地写入5份日志文件

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2019 logtube
+Copyright (c) Guo Y.K. 2019-2021 logtube
+Copyright (c) 蒙韶颖 2020-2021 logtube
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Logtube PHP SDK v1.2.0
                 "warn" => "xlog",
                 "info" => "xlog",
                 "x-access" => "xlog"
-            ]
+            ],
+            "balance" => 5, // 随机均衡写入 xx.1.log, xx.2.log, xx.3.log, xx.4.log, xx.5.log，最小可配置为1。
         ]
     ]);
     ```

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "logtube/logtube",
   "description": "PHP SDK for Logtube",
-  "version": "1.4.1",
+  "version": "1.5.1",
   "type": "library",
   "license": "MIT",
   "authors": [

--- a/tests/logtube/ContextTest.php
+++ b/tests/logtube/ContextTest.php
@@ -13,6 +13,7 @@ class ContextTest extends TestCase
             "project" => "testcase",
             "env" => "test",
             "crid" => "xxxxxx",
+            "crsrc" => "-",
             "file" => array(
                 "dir" => "logs",
                 "subdirs" => array(

--- a/tests/logtube/FileOutputTest.php
+++ b/tests/logtube/FileOutputTest.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * 测试 Logtube\Output\FileOutput
+ *
+ * @author MengShaoying
+ */
+use Logtube\Output\FileOutput;
+use Logtube\Event;
+use PHPUnit\Framework\TestCase;
+
+class FileOutputTest extends TestCase
+{
+    /**
+     * 测试创建目录能力。
+     *
+     * @return void
+     */
+    public function testCreateDir()
+    {
+        $tempDir = 'logs/' . uniqid() . '/' . uniqid();
+        FileOutput::createDirIfNotExisted($tempDir);
+        $this->assertTrue(is_dir($tempDir));
+        rmdir($tempDir);
+    }
+
+    /**
+     * 测试添加 event
+     *
+     * @return void
+     */
+    public function testAppend()
+    {
+        $today = date('Y-m-d');
+        $subdir = uniqid();
+        $env = 'local_' . uniqid();
+        $topic = 'topic_' . uniqid();
+        $project = 'project_' . uniqid();
+        $crid = 'crid_' . uniqid();
+        $crsrc = 'crsrc_' . uniqid();
+        $keywords = [uniqid(), uniqid(), uniqid()];
+        $extras = [
+            'ex-key-' . uniqid() => uniqid(),
+        ];
+        $message = 'Message=' . uniqid();
+
+        mt_srand(0); // 种子设置为0后mt_rand返回的第一个值是5
+        $logFile = 'logs/'.$subdir.'/'.$env.'.'.$topic.'.'.$project.'.'.$today.'.5.log';
+
+        $fOut = new FileOutput([
+            'dir' => 'logs',
+            'subdirs' => [
+                $topic => $subdir,
+            ],
+        ]);
+        $event = new Event();
+        $event->setEnv($env);
+        $event->setTopic($topic);
+        $event->setProject($project);
+        $event->setCrid($crid);
+        $event->setCrsrc($crsrc);
+        foreach ($keywords as $keyword) {
+            $event->addKeyword($keyword);
+        }
+        foreach ($extras as $name => $value) {
+            $event->addExtra($name, $value);
+        }
+        $event->setMessage($message);
+        $fOut->append($event);
+        $this->assertTrue(is_file($logFile));
+
+        $info = $this->parseLogFile($logFile);
+        $this->assertTrue(!empty($info));
+
+        $this->assertEquals($today, $info['date']);
+        $this->assertEquals($message, $info['message']);
+
+        $this->assertEquals($crid, $info['json'][0]['c']);
+        $this->assertEquals($crsrc, $info['json'][0]['s']);
+        $this->assertEquals(implode(',', $keywords), $info['json'][0]['k']);
+        $this->assertEquals(json_encode($extras), json_encode($info['json'][0]['x']));
+    }
+
+    /**
+     * 解析日志文件，文件中必须只有一条日志
+     *
+     * @param string $file 文件名称
+     * @return array
+     */
+    private function parseLogFile($fileName)
+    {
+        $data = file_get_contents($fileName);
+        $row = trim($data);
+        $temp = explode('] ', $row);
+        if (3 != count($temp)) {
+            return [];
+        }
+        $time = ltrim($temp[0], '[');
+        $date = explode(' ', $time);
+        $date = $date[0];
+        $logJsonArray = json_decode($temp[1] . ']', true);
+        if (empty($logJsonArray)) {
+            return [];
+        }
+        if (empty($temp[2])) {
+            return [];
+        }
+        return [
+            'date' => $date,
+            'json' => $logJsonArray,
+            'message' => $temp[2],
+        ];
+    }
+}


### PR DESCRIPTION
写入效果：
$ ls -alht /tmp/xlog_logs/app/
总用量 1.1M
-rw-r--r-- 1 meng meng 101K 5月  18 17:51 local.info.test-project.2021-05-18.1.log
-rw-r--r-- 1 meng meng 202K 5月  18 17:51 local.info.test-project.2021-05-18.2.log
-rw-r--r-- 1 meng meng 263K 5月  18 17:51 local.info.test-project.2021-05-18.3.log
-rw-r--r-- 1 meng meng 293K 5月  18 17:51 local.info.test-project.2021-05-18.5.log
-rw-r--r-- 1 meng meng 152K 5月  18 17:51 local.info.test-project.2021-05-18.4.log

单元测试，100%通过：
$ phpunit -c phpunit.xml
PHPUnit 10.0-dev by Sebastian Bergmann and contributors.

.....                                                               5 / 5 (100%)

Time: 00:01.009, Memory: 16.00 MB

OK (5 tests, 22 assertions)

本地临时脚本测试，50并发写200行10KB大日志能100%保持完整：
$ php verify.php 
空行=1
列数错误=0
JSON格式错误=0
消息内容错误=0
验证通过=200